### PR TITLE
Feat/delete workout by

### DIFF
--- a/src/main/java/igym/controllers/WorkoutController.java
+++ b/src/main/java/igym/controllers/WorkoutController.java
@@ -1,6 +1,7 @@
 package igym.controllers;
 
 import igym.entities.Workout;
+import igym.exceptions.WorkoutNotFoundException;
 import igym.services.WorkoutService;
 import jakarta.validation.Valid;
 
@@ -36,6 +37,26 @@ public class WorkoutController {
             @RequestBody @Valid Workout workout) {
         Workout createdWorkout = workoutService.createWorkout(workout, gymId);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdWorkout);
+    }
+
+    /**
+     * Soft deletes a workout and its associated exercises by marking their status
+     * as {@code Status.inactive}. This does not remove the workout from the
+     * database.
+     *
+     * <p>
+     * This operation allows for logical deletion, useful for auditing and potential
+     * recovery.
+     * </p>
+     *
+     * @param workoutId the UUID of the workout to delete
+     * @return {@link ResponseEntity#noContent()} if the deletion was successful
+     * @throws WorkoutNotFoundException if no workout is found with the given ID
+     */
+    @DeleteMapping("/workouts/{id}")
+    public ResponseEntity<Void> deleteWorkout(@PathVariable("id") UUID workoutId) {
+        workoutService.deleteWorkout(workoutId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/igym/entities/Exercise.java
+++ b/src/main/java/igym/entities/Exercise.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
+import igym.entities.enums.Status;
+
 /**
  * Represents an exercise within a workout.
  *
@@ -45,6 +47,10 @@ public class Exercise {
     private int numSets;
 
     private String note;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status = Status.active;
 
     @ManyToOne
     @JoinColumn(name = "workout_id", nullable = false)

--- a/src/main/java/igym/entities/Workout.java
+++ b/src/main/java/igym/entities/Workout.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
+import igym.entities.enums.Status;
+
 /**
  * Represents a workout plan which contains multiple exercises.
  * Lombok's @Setter is applied to the class, but the ID field
@@ -32,6 +34,10 @@ public class Workout {
     @Column(nullable = false, length = 50)
     @Size(min = 1, max = 50, message = "Name must be between 3 and 50 characters")
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status = Status.active;
 
     @NotEmpty(message = "Workout must contain at least one exercise")
     @OneToMany(mappedBy = "workout", cascade = CascadeType.ALL)

--- a/src/main/java/igym/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/igym/exceptions/GlobalExceptionHandler.java
@@ -73,4 +73,11 @@ public class GlobalExceptionHandler {
         Map<String, Object> body = buildResponseBody(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
     }
+
+    @ExceptionHandler(WorkoutNotFoundException.class)
+    public ResponseEntity<Object> handleWorkoutNotFoundException(WorkoutNotFoundException ex) {
+        logger.error(ex.getMessage());
+        Map<String, Object> body = buildResponseBody(HttpStatus.NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
 }

--- a/src/main/java/igym/exceptions/WorkoutNotFoundException.java
+++ b/src/main/java/igym/exceptions/WorkoutNotFoundException.java
@@ -1,0 +1,7 @@
+package igym.exceptions;
+
+public class WorkoutNotFoundException extends RuntimeException {
+    public WorkoutNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/igym/services/WorkoutService.java
+++ b/src/main/java/igym/services/WorkoutService.java
@@ -3,6 +3,8 @@ package igym.services;
 import igym.entities.Exercise;
 import igym.entities.Gym;
 import igym.entities.Workout;
+import igym.entities.enums.Status;
+import igym.exceptions.WorkoutNotFoundException;
 import igym.repositories.WorkoutRepository;
 import jakarta.transaction.Transactional;
 
@@ -39,5 +41,42 @@ public class WorkoutService {
         }
 
         return workoutRepository.save(workout);
+    }
+
+    /**
+     * Soft deletes a workout by marking its status (and the status of its
+     * exercises)
+     * as {@code Status.inactive}. This prevents the workout and its exercises from
+     * being
+     * returned in future queries unless explicitly requested.
+     *
+     * <p>
+     * This method throws a {@link igym.exceptions.WorkoutNotFoundException}
+     * if no workout with the given ID exists.
+     *
+     * <p>
+     * Note: The workout is still persisted in the database with status
+     * {@code inactive}, allowing for potential recovery or auditing.
+     *
+     * @param workoutId the UUID of the workout to soft delete
+     * @throws igym.exceptions.WorkoutNotFoundException if no workout is found with
+     *                                                  the given ID
+     */
+    @Transactional
+    public void deleteWorkout(UUID workoutId) {
+        Workout workout = workoutRepository.findById(workoutId)
+                .orElseThrow(() -> new WorkoutNotFoundException("Workout with id " + workoutId + " not found"));
+
+        if (workout.getStatus() == Status.inactive) {
+            throw new WorkoutNotFoundException("Workout with id " + workoutId + " not found");
+        }
+
+        workout.setStatus(Status.inactive);
+
+        if (workout.getExerciseList() != null) {
+            workout.getExerciseList().forEach(ex -> ex.setStatus(Status.inactive));
+        }
+
+        workoutRepository.save(workout);
     }
 }

--- a/src/main/java/igym/services/WorkoutService.java
+++ b/src/main/java/igym/services/WorkoutService.java
@@ -1,19 +1,21 @@
 package igym.services;
 
-import igym.entities.Exercise;
 import igym.entities.Gym;
 import igym.entities.Workout;
 import igym.entities.enums.Status;
 import igym.exceptions.WorkoutNotFoundException;
 import igym.repositories.WorkoutRepository;
 import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
-import org.springframework.stereotype.Service;
-
 @Service
 public class WorkoutService {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkoutService.class);
 
     private final WorkoutRepository workoutRepository;
     private final GymService gymService;
@@ -25,58 +27,63 @@ public class WorkoutService {
 
     /**
      * Creates a new workout with its list of exercises.
-     * 
+     *
      * @param workout the workout entity to save
      * @return the saved workout
      */
     @Transactional
     public Workout createWorkout(Workout workout, UUID gymId) {
+        logger.info("Attempting to create a new workout for gym with id: {}", gymId);
+        logger.debug("Workout creation request with values: {}", workout);
+
         Gym gym = gymService.findById(gymId);
         workout.setGym(gym);
 
         if (workout.getExerciseList() != null) {
-            for (Exercise exercise : workout.getExerciseList()) {
+            workout.getExerciseList().forEach(exercise -> {
                 exercise.setWorkout(workout);
-            }
+                logger.debug("Setting workout reference for exercise: {}", exercise);
+            });
         }
 
-        return workoutRepository.save(workout);
+        Workout savedWorkout = workoutRepository.save(workout);
+        logger.info("New workout created with id: {}", savedWorkout.getId());
+        logger.debug("New workout persisted: {}", savedWorkout);
+        return savedWorkout;
     }
 
     /**
      * Soft deletes a workout by marking its status (and the status of its
-     * exercises)
-     * as {@code Status.inactive}. This prevents the workout and its exercises from
-     * being
-     * returned in future queries unless explicitly requested.
-     *
-     * <p>
-     * This method throws a {@link igym.exceptions.WorkoutNotFoundException}
-     * if no workout with the given ID exists.
-     *
-     * <p>
-     * Note: The workout is still persisted in the database with status
-     * {@code inactive}, allowing for potential recovery or auditing.
+     * exercises) as {@code Status.inactive}.
      *
      * @param workoutId the UUID of the workout to soft delete
-     * @throws igym.exceptions.WorkoutNotFoundException if no workout is found with
-     *                                                  the given ID
      */
     @Transactional
     public void deleteWorkout(UUID workoutId) {
+        logger.info("Attempting to delete workout with id: {}", workoutId);
+
         Workout workout = workoutRepository.findById(workoutId)
-                .orElseThrow(() -> new WorkoutNotFoundException("Workout with id " + workoutId + " not found"));
+                .orElseThrow(() -> {
+                    logger.warn("Workout with id {} not found", workoutId);
+                    return new WorkoutNotFoundException("Workout with id " + workoutId + " not found");
+                });
 
         if (workout.getStatus() == Status.inactive) {
+            logger.warn("Workout with id {} is already inactive", workoutId);
             throw new WorkoutNotFoundException("Workout with id " + workoutId + " not found");
         }
 
         workout.setStatus(Status.inactive);
+        logger.info("Workout with id {} marked as inactive", workoutId);
 
         if (workout.getExerciseList() != null) {
-            workout.getExerciseList().forEach(ex -> ex.setStatus(Status.inactive));
+            workout.getExerciseList().forEach(ex -> {
+                ex.setStatus(Status.inactive);
+                logger.debug("Exercise with id {} marked as inactive", ex.getId());
+            });
         }
 
         workoutRepository.save(workout);
+        logger.info("Workout with id {} and its exercises have been inactivated", workoutId);
     }
 }

--- a/src/test/java/igym/controllers/WorkoutControllerTest.java
+++ b/src/test/java/igym/controllers/WorkoutControllerTest.java
@@ -203,7 +203,7 @@ public class WorkoutControllerTest {
 
                 doNothing().when(workoutService).deleteWorkout(workoutId);
 
-                mockMvc.perform(delete("/api/{id}", workoutId))
+                mockMvc.perform(delete("/api/workouts/{id}", workoutId))
                                 .andExpect(status().isNoContent());
 
                 verify(workoutService, times(1)).deleteWorkout(workoutId);
@@ -217,7 +217,7 @@ public class WorkoutControllerTest {
                 doThrow(new WorkoutNotFoundException("Workout not found")).when(workoutService)
                                 .deleteWorkout(workoutId);
 
-                mockMvc.perform(delete("/api/{id}", workoutId))
+                mockMvc.perform(delete("/api/workouts/{id}", workoutId))
                                 .andExpect(status().isNotFound());
 
                 verify(workoutService, times(1)).deleteWorkout(workoutId);

--- a/src/test/java/igym/controllers/WorkoutControllerTest.java
+++ b/src/test/java/igym/controllers/WorkoutControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import igym.entities.Exercise;
 import igym.entities.Workout;
+import igym.exceptions.WorkoutNotFoundException;
 import igym.services.WorkoutService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WorkoutController.class)
@@ -193,6 +194,33 @@ public class WorkoutControllerTest {
                                 .andExpect(status().isInternalServerError());
 
                 verify(workoutService, times(1)).createWorkout(any(Workout.class), eq(gymId));
+        }
+
+        @Test
+        @DisplayName("should return 204 No Content when deleting existing workout")
+        void testDeleteWorkoutSuccess() throws Exception {
+                UUID workoutId = UUID.randomUUID();
+
+                doNothing().when(workoutService).deleteWorkout(workoutId);
+
+                mockMvc.perform(delete("/api/{id}", workoutId))
+                                .andExpect(status().isNoContent());
+
+                verify(workoutService, times(1)).deleteWorkout(workoutId);
+        }
+
+        @Test
+        @DisplayName("should return 404 Not Found when workout does not exist")
+        void testDeleteWorkoutNotFound() throws Exception {
+                UUID workoutId = UUID.randomUUID();
+
+                doThrow(new WorkoutNotFoundException("Workout not found")).when(workoutService)
+                                .deleteWorkout(workoutId);
+
+                mockMvc.perform(delete("/api/{id}", workoutId))
+                                .andExpect(status().isNotFound());
+
+                verify(workoutService, times(1)).deleteWorkout(workoutId);
         }
 
 }

--- a/src/test/java/igym/entities/ExerciseTest.java
+++ b/src/test/java/igym/entities/ExerciseTest.java
@@ -2,6 +2,7 @@ package igym.entities;
 
 import jakarta.validation.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,6 +14,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import igym.entities.enums.Status;
+
 class ExerciseTest {
 
     private static Validator validator;
@@ -22,9 +25,9 @@ class ExerciseTest {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
     }
-    
+
     @Test
-    @DisplayName("Test valid exercise") 
+    @DisplayName("Test valid exercise")
     void testValidExercise() {
         Exercise ex = new Exercise();
         ex.setName("Bench Press");
@@ -92,6 +95,19 @@ class ExerciseTest {
 
         Set<ConstraintViolation<Exercise>> violations = validator.validate(ex);
         assertFalse(violations.isEmpty(), "Expected violation for sets: " + invalidSets);
+    }
+
+    @Test
+    @DisplayName("Test exercise default status is active")
+    void testExerciseDefaultStatus() {
+        Exercise ex = new Exercise();
+        ex.setName("Lunge");
+        ex.setWeight(40);
+        ex.setNumReps(12);
+        ex.setNumSets(3);
+        Set<ConstraintViolation<Exercise>> violations = validator.validate(ex);
+        assertTrue(violations.isEmpty());
+        assertEquals(Status.active, ex.getStatus(), "Default status should be active");
     }
 
 }

--- a/src/test/java/igym/entities/WorkoutTest.java
+++ b/src/test/java/igym/entities/WorkoutTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 
+import igym.entities.enums.Status;
+
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -74,4 +76,14 @@ class WorkoutTest {
         assertFalse(violations.isEmpty(), "Expected violation for null exercise list");
     }
 
+    @Test
+    @DisplayName("Test workout default status is active")
+    void testWorkoutDefaultStatus() {
+        Workout workout = new Workout();
+        workout.setName("Core Day");
+        workout.setExerciseList(List.of(createValidExercise()));
+        Set<ConstraintViolation<Workout>> violations = validator.validate(workout);
+        assertTrue(violations.isEmpty());
+        assertEquals(Status.active, workout.getStatus(), "Default status should be active");
+    }
 }

--- a/src/test/java/igym/services/UserServiceTest.java
+++ b/src/test/java/igym/services/UserServiceTest.java
@@ -83,6 +83,7 @@ class UserServiceTest {
         verify(repository, never()).save(user1);
     }
 
+    @Test
     @DisplayName("Should return a list that contains the saved user")
     void createUserTest() {
         when(repository.save(user1)).thenReturn(user1);

--- a/src/test/java/igym/services/WorkoutServiceTest.java
+++ b/src/test/java/igym/services/WorkoutServiceTest.java
@@ -64,7 +64,7 @@ class WorkoutServiceTest {
     void testCreateWorkoutWithNullExerciseList() {
         Workout workout = new Workout();
         workout.setName("Stretching Routine");
-        workout.setExerciseList(null); // important
+        workout.setExerciseList(null);
 
         when(gymService.findById(gymId)).thenReturn(new Gym("Test Gym"));
         when(workoutRepository.save(any(Workout.class))).thenReturn(workout);

--- a/src/test/java/igym/services/WorkoutServiceTest.java
+++ b/src/test/java/igym/services/WorkoutServiceTest.java
@@ -60,6 +60,22 @@ class WorkoutServiceTest {
     }
 
     @Test
+    @DisplayName("Should create workout when exercise list is null")
+    void testCreateWorkoutWithNullExerciseList() {
+        Workout workout = new Workout();
+        workout.setName("Stretching Routine");
+        workout.setExerciseList(null); // important
+
+        when(gymService.findById(gymId)).thenReturn(new Gym("Test Gym"));
+        when(workoutRepository.save(any(Workout.class))).thenReturn(workout);
+
+        Workout result = workoutService.createWorkout(workout, gymId);
+
+        assertEquals("Stretching Routine", result.getName());
+        verify(workoutRepository, times(1)).save(workout);
+    }
+
+    @Test
     @DisplayName("Should return an exeception when gym not found in workout creation")
     void testGymNotFoundInWorkoutCreation() {
         Exercise ex = new Exercise();
@@ -131,7 +147,7 @@ class WorkoutServiceTest {
 
         Workout workout = new Workout();
         workout.setName("Cardio Day");
-        workout.setStatus(Status.inactive); 
+        workout.setStatus(Status.inactive);
 
         when(workoutRepository.findById(workoutId)).thenReturn(java.util.Optional.of(workout));
 
@@ -143,6 +159,24 @@ class WorkoutServiceTest {
         verify(workoutRepository, times(1)).findById(workoutId);
         verify(workoutRepository, never()).save(any());
         assertEquals(Status.inactive, workout.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should delete workout with no exercises")
+    void testDeleteWorkoutWithNoExercises() {
+        UUID workoutId = UUID.randomUUID();
+
+        Workout workout = new Workout();
+        workout.setName("Cardio Day");
+        workout.setStatus(Status.active);
+        workout.setExerciseList(null);
+
+        when(workoutRepository.findById(workoutId)).thenReturn(java.util.Optional.of(workout));
+
+        workoutService.deleteWorkout(workoutId);
+
+        assertEquals(Status.inactive, workout.getStatus());
+        verify(workoutRepository).save(workout);
     }
 
 }


### PR DESCRIPTION
# Delete WorkoutByID Endpoint

## Description

1. Develop delete endpoint that logically deletes workout by ID
2. Use Javadoc
3. When deleteting workout, all its Exercise’s should be deleted


## Checklist
- [x] All acceptance criteria have been met
- [x] My code follows the project's coding style.
- [x] I have documented my code
- [x] I wrote unit tests for the changes that I made

## Task in Notion
[task on notion](https://www.notion.so/16bb8830dc7b8068807af79065c08418?v=16bb8830dc7b801292da000c63c754b1&p=1ceb8830dc7b8046a09dea82ed7f6aaa&pm=s)
