### PR TITLE
Feat/refactor services

### DIFF
--- a/src/main/java/igym/controllers/GymController.java
+++ b/src/main/java/igym/controllers/GymController.java
@@ -76,7 +76,7 @@ public class GymController {
      */
     @GetMapping(value = "/gyms", produces = "application/json")
     public ResponseEntity<List<GymDTO>> findAllGyms() {
-        List<GymDTO> gyms = service.findAllGyms().stream().map(GymDTO::new).toList();
+        List<GymDTO> gyms = service.findAll().stream().map(GymDTO::new).toList();
         return ResponseEntity.ok(gyms);
     }
 

--- a/src/main/java/igym/dtos/WorkoutDTO.java
+++ b/src/main/java/igym/dtos/WorkoutDTO.java
@@ -38,7 +38,6 @@ public record WorkoutDTO(
                 workout.getUpdated_at(),
                 workout.getGym().getId(),
                 workout.getExerciseList().stream()
-                        .filter(ex -> ex.getStatus() == Status.active)
                         .map(ExerciseDTO::new)
                         .collect(Collectors.toList()));
     }

--- a/src/main/java/igym/dtos/WorkoutDTO.java
+++ b/src/main/java/igym/dtos/WorkoutDTO.java
@@ -19,27 +19,27 @@ import java.util.stream.Collectors;
  * @param name         the name of the workout
  * @param status       the current status (active/inactive) of the workout
  * @param updated_at   the timestamp of the last update
- * @param gym_id       the unique identifier of the gym associated with this workout
+ * @param gym_id       the unique identifier of the gym associated with this
+ *                     workout
  * @param exerciseList the list of exercises in this workout
  */
 public record WorkoutDTO(
-    UUID id,
-    String name,
-    Status status,
-    Instant updated_at,
-    UUID gym_id,
-    List<ExerciseDTO> exerciseList
-) {
-        public WorkoutDTO(Workout workout) {
+        UUID id,
+        String name,
+        Status status,
+        Instant updated_at,
+        UUID gym_id,
+        List<ExerciseDTO> exerciseList) {
+    public WorkoutDTO(Workout workout) {
         this(
-            workout.getId(),
-            workout.getName(),
-            workout.getStatus(),
-            workout.getUpdated_at(),
-            workout.getGym().getId(),
-            workout.getExerciseList().stream()
-                .map(ExerciseDTO::new)
-                .collect(Collectors.toList())
-        );
+                workout.getId(),
+                workout.getName(),
+                workout.getStatus(),
+                workout.getUpdated_at(),
+                workout.getGym().getId(),
+                workout.getExerciseList().stream()
+                        .filter(ex -> ex.getStatus() == Status.active)
+                        .map(ExerciseDTO::new)
+                        .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/igym/repositories/GymRepository.java
+++ b/src/main/java/igym/repositories/GymRepository.java
@@ -33,7 +33,7 @@ public interface GymRepository extends JpaRepository<Gym, UUID> {
     boolean existsByNameAndUserIdAndStatus(String name, UUID userId, Status status);
 
     /**
-     * finds all gyms by its status
+     * Finds all gyms by its status
      * @param status
      * @return a list of gyms with the given status
      */

--- a/src/main/java/igym/repositories/GymRepository.java
+++ b/src/main/java/igym/repositories/GymRepository.java
@@ -32,5 +32,12 @@ public interface GymRepository extends JpaRepository<Gym, UUID> {
      */
     boolean existsByNameAndUserIdAndStatus(String name, UUID userId, Status status);
 
+    /**
+     * finds all gyms by its status
+     * @param status
+     * @return a list of gyms with the given status
+     */
+    List<Gym> findByStatus(Status status);
+
     List<Gym> findByUserIdAndStatus(UUID userId, Status status);
 }

--- a/src/main/java/igym/repositories/UserRepository.java
+++ b/src/main/java/igym/repositories/UserRepository.java
@@ -1,10 +1,10 @@
 package igym.repositories;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.NonNull;
-
 import igym.entities.User;
 import igym.entities.enums.Status;
 
@@ -21,7 +21,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
      */
     public boolean existsById(@NonNull UUID id);
 
-
     /**
      * Checks if a user with the specified name exists with the specified status.
      *
@@ -29,4 +28,11 @@ public interface UserRepository extends JpaRepository<User, UUID> {
      * @return true if a user with the given name exists, false otherwise
      */
     public boolean existsByNameAndStatus(String name, Status status);
+
+    /**
+     * Finds all users by their status.
+     * @param status
+     * @return a list of users with the given status
+     */
+    List<User> findByStatus(Status status);
 }

--- a/src/main/java/igym/repositories/WorkoutRepository.java
+++ b/src/main/java/igym/repositories/WorkoutRepository.java
@@ -21,6 +21,6 @@ public interface WorkoutRepository extends JpaRepository<Workout, UUID> {
      * @param gym the gym entity
      * @return a list of workouts belonging to the specified gym
      */
-    List<Workout> findByGym(Gym gym);
+    List<Workout> findByGymAndStatus(Gym gym, Status status);
     Optional<Workout> findByIdAndStatus(UUID id, Status status);
 }

--- a/src/main/java/igym/services/GymService.java
+++ b/src/main/java/igym/services/GymService.java
@@ -99,9 +99,9 @@ public class GymService {
      *
      * @return a list of all gyms
      */
-    public List<Gym> findAllGyms() {
+    public List<Gym> findAll() {
         logger.info("Fetching all gyms from the repository");
-        List<Gym> gyms = gymRepository.findAll();
+        List<Gym> gyms = gymRepository.findByStatus(Status.active);
         logger.info("Found {} gyms", gyms.size());
         logger.debug("Fetched gyms: {}", gyms);
         return gyms;

--- a/src/main/java/igym/services/UserService.java
+++ b/src/main/java/igym/services/UserService.java
@@ -43,7 +43,7 @@ public class UserService {
      */
     public List<User> findAll() {
         logger.info("Fetching all users from the repository");
-        List<User> users = repository.findAll();
+        List<User> users = repository.findByStatus(Status.active);
         logger.info("Found {} users", users.size());
         logger.debug("Fetched users: {}", users);
         return users;

--- a/src/main/java/igym/services/WorkoutService.java
+++ b/src/main/java/igym/services/WorkoutService.java
@@ -1,6 +1,5 @@
 package igym.services;
 
-import igym.dtos.WorkoutDTO;
 import igym.entities.Exercise;
 import igym.entities.Gym;
 import igym.entities.Workout;
@@ -85,9 +84,7 @@ public class WorkoutService {
      */
     public List<Workout> getWorkoutsByGymId(UUID gymId) {
         Gym gym = findGymById(gymId);
-        return workoutRepository.findByGym(gym).stream()
-                .filter(w -> w.getStatus() == Status.active)
-                .toList();
+        return workoutRepository.findByGymAndStatus(gym, Status.active);
     }
 
     /**

--- a/src/main/java/igym/services/WorkoutService.java
+++ b/src/main/java/igym/services/WorkoutService.java
@@ -84,7 +84,18 @@ public class WorkoutService {
      */
     public List<Workout> getWorkoutsByGymId(UUID gymId) {
         Gym gym = findGymById(gymId);
-        return workoutRepository.findByGymAndStatus(gym, Status.active);
+        List<Workout> workouts = workoutRepository.findByGymAndStatus(gym, Status.active);
+
+        workouts.forEach(workout -> {
+            if (workout.getExerciseList() != null) {
+                List<Exercise> activeExercises = workout.getExerciseList().stream()
+                        .filter(e -> e.getStatus() == Status.active)
+                        .toList();
+                workout.setExerciseList(activeExercises);
+            }
+        });
+
+        return workouts;
     }
 
     /**

--- a/src/main/java/igym/services/WorkoutService.java
+++ b/src/main/java/igym/services/WorkoutService.java
@@ -1,5 +1,6 @@
 package igym.services;
 
+import igym.dtos.WorkoutDTO;
 import igym.entities.Exercise;
 import igym.entities.Gym;
 import igym.entities.Workout;
@@ -84,7 +85,9 @@ public class WorkoutService {
      */
     public List<Workout> getWorkoutsByGymId(UUID gymId) {
         Gym gym = findGymById(gymId);
-        return workoutRepository.findByGym(gym);
+        return workoutRepository.findByGym(gym).stream()
+                .filter(w -> w.getStatus() == Status.active)
+                .toList();
     }
 
     /**

--- a/src/test/java/igym/controllers/GymControllerTest.java
+++ b/src/test/java/igym/controllers/GymControllerTest.java
@@ -181,7 +181,7 @@ public class GymControllerTest {
         void testFindAllGymsError() throws Exception {
                 when(gymService.findAll()).thenThrow(new RuntimeException("Internal server error"));
 
-                mockMvc.perform(get("/api/"))
+                mockMvc.perform(get("/api/gyms"))
                                 .andExpect(status().isInternalServerError());
 
                 verify(gymService, times(1)).findAll();

--- a/src/test/java/igym/controllers/GymControllerTest.java
+++ b/src/test/java/igym/controllers/GymControllerTest.java
@@ -166,25 +166,25 @@ public class GymControllerTest {
         @DisplayName("should return all the gyms from the service and status 200")
         void testFindAllGymsSuccess() throws Exception {
                 List<Gym> gyms = Arrays.asList(gym1, gym2);
-                when(gymService.findAllGyms()).thenReturn(gyms);
+                when(gymService.findAll()).thenReturn(gyms);
 
                 mockMvc.perform(get("/api/gyms"))
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$[0].name").value("Location 1"))
                                 .andExpect(jsonPath("$[1].name").value("Location 2"));
 
-                verify(gymService, times(1)).findAllGyms();
+                verify(gymService, times(1)).findAll();
         }
 
         @Test
         @DisplayName("should return an exception and status 500")
         void testFindAllGymsError() throws Exception {
-                when(gymService.findAllGyms()).thenThrow(new RuntimeException("Internal server error"));
+                when(gymService.findAll()).thenThrow(new RuntimeException("Internal server error"));
 
-                mockMvc.perform(get("/api/gyms"))
+                mockMvc.perform(get("/api/"))
                                 .andExpect(status().isInternalServerError());
 
-                verify(gymService, times(1)).findAllGyms();
+                verify(gymService, times(1)).findAll();
         }
 
         @Test

--- a/src/test/java/igym/controllers/WorkoutControllerTest.java
+++ b/src/test/java/igym/controllers/WorkoutControllerTest.java
@@ -234,38 +234,6 @@ public class WorkoutControllerTest {
 
         }
 
-        @Test
-        @DisplayName("should return workout with empty exercise list when exercises are inactive")
-        void testGetWorkoutWithInactiveExercises() throws Exception {
-                Exercise inactiveExercise = new Exercise();
-                ReflectionTestUtils.setField(inactiveExercise, "id", UUID.randomUUID());
-                inactiveExercise.setName("Deadlift");
-                inactiveExercise.setWeight(100);
-                inactiveExercise.setNumReps(8);
-                inactiveExercise.setNumSets(3);
-                inactiveExercise.setStatus(igym.entities.enums.Status.inactive);
-
-                Workout workoutWithInactiveExercise = new Workout();
-                ReflectionTestUtils.setField(workoutWithInactiveExercise, "id", UUID.randomUUID());
-                workoutWithInactiveExercise.setName("Back Day");
-                workoutWithInactiveExercise.setStatus(igym.entities.enums.Status.active);
-                workoutWithInactiveExercise.setExerciseList(List.of(inactiveExercise));
-                workoutWithInactiveExercise.setGym(gym);
-                inactiveExercise.setWorkout(workoutWithInactiveExercise);
-
-                when(workoutService.getWorkoutsByGymId(gymId)).thenReturn(List.of(workoutWithInactiveExercise));
-
-                mockMvc.perform(get("/api/gyms/{gymId}/workouts", gymId)
-                                .contentType(MediaType.APPLICATION_JSON))
-                                .andExpect(status().isOk())
-                                .andExpect(jsonPath("$.length()").value(1))
-                                .andExpect(jsonPath("$[0].name").value("Back Day"))
-                                .andExpect(jsonPath("$[0].exerciseList").isArray())
-                                .andExpect(jsonPath("$[0].exerciseList").isEmpty());
-
-                verify(workoutService, times(1)).getWorkoutsByGymId(gymId);
-        }
-
         @DisplayName("should return 204 No Content when deleting existing workout")
         void testDeleteWorkoutSuccess() throws Exception {
                 UUID workoutId = UUID.randomUUID();

--- a/src/test/java/igym/controllers/WorkoutControllerTest.java
+++ b/src/test/java/igym/controllers/WorkoutControllerTest.java
@@ -234,6 +234,38 @@ public class WorkoutControllerTest {
 
         }
 
+        @Test
+        @DisplayName("should return workout with empty exercise list when exercises are inactive")
+        void testGetWorkoutWithInactiveExercises() throws Exception {
+                Exercise inactiveExercise = new Exercise();
+                ReflectionTestUtils.setField(inactiveExercise, "id", UUID.randomUUID());
+                inactiveExercise.setName("Deadlift");
+                inactiveExercise.setWeight(100);
+                inactiveExercise.setNumReps(8);
+                inactiveExercise.setNumSets(3);
+                inactiveExercise.setStatus(igym.entities.enums.Status.inactive);
+
+                Workout workoutWithInactiveExercise = new Workout();
+                ReflectionTestUtils.setField(workoutWithInactiveExercise, "id", UUID.randomUUID());
+                workoutWithInactiveExercise.setName("Back Day");
+                workoutWithInactiveExercise.setStatus(igym.entities.enums.Status.active);
+                workoutWithInactiveExercise.setExerciseList(List.of(inactiveExercise));
+                workoutWithInactiveExercise.setGym(gym);
+                inactiveExercise.setWorkout(workoutWithInactiveExercise);
+
+                when(workoutService.getWorkoutsByGymId(gymId)).thenReturn(List.of(workoutWithInactiveExercise));
+
+                mockMvc.perform(get("/api/gyms/{gymId}/workouts", gymId)
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.length()").value(1))
+                                .andExpect(jsonPath("$[0].name").value("Back Day"))
+                                .andExpect(jsonPath("$[0].exerciseList").isArray())
+                                .andExpect(jsonPath("$[0].exerciseList").isEmpty());
+
+                verify(workoutService, times(1)).getWorkoutsByGymId(gymId);
+        }
+
         @DisplayName("should return 204 No Content when deleting existing workout")
         void testDeleteWorkoutSuccess() throws Exception {
                 UUID workoutId = UUID.randomUUID();

--- a/src/test/java/igym/services/GymServiceTest.java
+++ b/src/test/java/igym/services/GymServiceTest.java
@@ -128,23 +128,30 @@ public class GymServiceTest {
     }
 
     @Test
-    @DisplayName("should return all gyms from the repository")
+    @DisplayName("should return all active gyms from the repository")
     void testFindAllGyms() {
         List<Gym> gyms = List.of(new Gym("Gym A"), new Gym("Gym B"), new Gym("Gym C"));
 
-        when(gymRepository.findAll()).thenReturn(gyms);
+        when(gymRepository.findByStatus(Status.active)).thenReturn(gyms);
 
-        List<Gym> result = gymService.findAllGyms();
+        List<Gym> result = gymService.findAll();
 
         assertThat(result).hasSize(3);
         assertThat(result).containsExactlyInAnyOrderElementsOf(gyms);
     }
 
     @Test
-    @DisplayName("the service should return an empty list if there are no gyms in the repository")
-    void testGymsNotFound() {
-        List<Gym> gyms = gymService.findAllGyms();
-        assertThat(gyms).isEmpty();
+    @DisplayName("the service should return an empty list if there are no gyms in the repository or all are inactive")
+    void testFindAllGymsEmpty() {
+        Gym gym = new Gym("Gym A");
+        ReflectionTestUtils.setField(gym, "id", UUID.randomUUID());
+        gym.setStatus(Status.inactive);
+
+        when(gymRepository.findByStatus(Status.active)).thenReturn(List.of());
+
+        List<Gym> result = gymService.findAll();
+
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/src/test/java/igym/services/UserServiceTest.java
+++ b/src/test/java/igym/services/UserServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/java/igym/services/UserServiceTest.java
+++ b/src/test/java/igym/services/UserServiceTest.java
@@ -50,18 +50,19 @@ class UserServiceTest {
     @Test
     @DisplayName("Should return the list of saved users")
     void findAllTest() {
-        List<User> users = new ArrayList<>();
-        users.add(user1);
-        users.add(user2);
-        when(userRepository.findAll()).thenReturn(users);
+        List<User> users = List.of(user1, user2);
+        
+        when(userRepository.findByStatus(Status.active)).thenReturn(users);
+
         List<User> listUsers = userService.findAll();
-        assertIterableEquals(listUsers, users);
+        assertThat(listUsers).hasSize(2);
+        assertThat(listUsers).containsExactlyInAnyOrderElementsOf(users);
     }
 
     @Test
     @DisplayName("Should return an empty list if no user was saved")
     void emptyListTest() {
-        when(userRepository.findAll()).thenReturn(List.of());
+        when(userRepository.findByStatus(Status.active)).thenReturn(List.of());
         List<User> list = userService.findAll();
         assertTrue(list.isEmpty());
     }

--- a/src/test/java/igym/services/WorkoutServiceTest.java
+++ b/src/test/java/igym/services/WorkoutServiceTest.java
@@ -144,6 +144,35 @@ class WorkoutServiceTest {
     }
 
     @Test
+    @DisplayName("Should return empty list of workouts when the workouts are inactive")
+    void testGetWorkoutsByGymIdInactive() {
+        Gym gym = new Gym("My Gym");
+        UUID gymId = UUID.randomUUID();
+
+        Exercise ex1 = new Exercise();
+        ex1.setName("Pushup");
+        ex1.setWeight(0);
+        ex1.setNumReps(15);
+        ex1.setNumSets(3);
+        ex1.setStatus(Status.inactive);
+
+        Workout workout1 = new Workout();
+        workout1.setName("Upper Body");
+        workout1.setExerciseList(List.of(ex1));
+        workout1.setGym(gym);
+        workout1.setStatus(Status.inactive);
+
+        when(gymRepository.findById(gymId)).thenReturn(Optional.of(gym));
+        when(workoutRepository.findByGym(gym)).thenReturn(List.of(workout1));
+
+        List<Workout> workouts = workoutService.getWorkoutsByGymId(gymId);
+
+        assertEquals(0, workouts.size());
+        verify(gymRepository, times(1)).findById(gymId);
+        verify(workoutRepository, times(1)).findByGym(gym);
+    }
+
+    @Test
     @DisplayName("Should throw GymNotFoundException when gym ID does not exist in getWorkoutsByGymId")
     void testGetWorkoutsByGymIdGymNotFound() {
         UUID gymId = UUID.randomUUID();

--- a/src/test/java/igym/services/WorkoutServiceTest.java
+++ b/src/test/java/igym/services/WorkoutServiceTest.java
@@ -173,6 +173,38 @@ class WorkoutServiceTest {
     }
 
     @Test
+    @DisplayName("Should return not return inactive exercises when workout is active in getWorkoutsByGymId")
+    void testGetWorkoutsByGymIdInactiveExercises() {
+        Gym gym = new Gym("My Gym");
+        UUID gymId = UUID.randomUUID();
+
+        Exercise ex1 = new Exercise();
+        ex1.setName("Pushup");
+        ex1.setWeight(0);
+        ex1.setNumReps(15);
+        ex1.setNumSets(3);
+        ex1.setStatus(Status.inactive);
+
+        Workout workout1 = new Workout();
+        workout1.setName("Upper Body");
+        workout1.setExerciseList(List.of(ex1));
+        workout1.setGym(gym);
+        workout1.setStatus(Status.active);
+
+        when(gymRepository.findById(gymId)).thenReturn(Optional.of(gym));
+        when(workoutRepository.findByGymAndStatus(gym, Status.active)).thenReturn(List.of(workout1));
+
+        List<Workout> workouts = workoutService.getWorkoutsByGymId(gymId);
+
+        assertEquals(1, workouts.size());
+        assertEquals("Upper Body", workouts.get(0).getName());
+        assertEquals(0, workouts.get(0).getExerciseList().size());
+
+        verify(gymRepository, times(1)).findById(gymId);
+        verify(workoutRepository, times(1)).findByGymAndStatus(gym, Status.active);
+    }
+
+    @Test
     @DisplayName("Should throw GymNotFoundException when gym ID does not exist in getWorkoutsByGymId")
     void testGetWorkoutsByGymIdGymNotFound() {
         UUID gymId = UUID.randomUUID();

--- a/src/test/java/igym/services/WorkoutServiceTest.java
+++ b/src/test/java/igym/services/WorkoutServiceTest.java
@@ -131,7 +131,7 @@ class WorkoutServiceTest {
         workout2.setGym(gym);
 
         when(gymRepository.findById(gymId)).thenReturn(Optional.of(gym));
-        when(workoutRepository.findByGym(gym)).thenReturn(List.of(workout1, workout2));
+        when(workoutRepository.findByGymAndStatus(gym, Status.active)).thenReturn(List.of(workout1, workout2));
 
         List<Workout> workouts = workoutService.getWorkoutsByGymId(gymId);
 
@@ -140,7 +140,7 @@ class WorkoutServiceTest {
         assertEquals("Leg Day", workouts.get(1).getName());
 
         verify(gymRepository, times(1)).findById(gymId);
-        verify(workoutRepository, times(1)).findByGym(gym);
+        verify(workoutRepository, times(1)).findByGymAndStatus(gym, Status.active);
     }
 
     @Test
@@ -163,20 +163,22 @@ class WorkoutServiceTest {
         workout1.setStatus(Status.inactive);
 
         when(gymRepository.findById(gymId)).thenReturn(Optional.of(gym));
-        when(workoutRepository.findByGym(gym)).thenReturn(List.of(workout1));
+        when(workoutRepository.findByGymAndStatus(gym, Status.active)).thenReturn(List.of());
 
         List<Workout> workouts = workoutService.getWorkoutsByGymId(gymId);
 
         assertEquals(0, workouts.size());
         verify(gymRepository, times(1)).findById(gymId);
-        verify(workoutRepository, times(1)).findByGym(gym);
+        verify(workoutRepository, times(1)).findByGymAndStatus(gym, Status.active);
     }
 
     @Test
     @DisplayName("Should throw GymNotFoundException when gym ID does not exist in getWorkoutsByGymId")
     void testGetWorkoutsByGymIdGymNotFound() {
         UUID gymId = UUID.randomUUID();
+        Gym gym = new Gym("My Gym");
 
+        when(gymRepository.findById(gymId)).thenReturn(Optional.of(gym));
         when(gymRepository.findById(gymId)).thenReturn(Optional.empty());
 
         GymNotFoundException exception = assertThrows(
@@ -185,7 +187,7 @@ class WorkoutServiceTest {
 
         assertEquals("Gym with id " + gymId + " not found", exception.getMessage());
         verify(gymRepository, times(1)).findById(gymId);
-        verify(workoutRepository, never()).findByGym(any());
+        verify(workoutRepository, never()).findByGymAndStatus(gym, Status.active);
 
     }
 


### PR DESCRIPTION
<!--Mention below the name of your Pull Request-->
# Pull Request Name
Refactoring services

## Description
The route get all and get workouts it is returning inactivated entities. We only need to return the active entities. The routes that were changed and should be tested on postman are the routes get all for user and gyms and the get workouts by gym id (should return just workout and exercises active). Exercises are impossible to test totally in postman because the route delete exercises is not in the main but a proper filter was added to workouts DTO to filter for active exercises. 

## Checklist
- [x] All acceptance criteria have been met
- [x] My code follows the project's coding style.
- [x] I have documented my code
- [x] I wrote unit tests for the changes that I made

## Task in Notion
[task link](https://app.clickup.com/t/86etb6xq7)
